### PR TITLE
fix: マーカークリック後の矢印キーでフォーカス枠が表示される問題を修正

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -133,6 +133,7 @@
     // クリックでシーク
     marker.addEventListener('click', (e) => {
       e.stopPropagation();
+      marker.blur();
       // 元の <a> に合成クリックを送る（YouTube のハンドラを発火させる）
       if (linkEl) {
         try {

--- a/src/overlay.css
+++ b/src/overlay.css
@@ -14,6 +14,7 @@
   );
   pointer-events: auto;
   z-index: 1000; /* プレイヤーUIより前面に */
+  outline: none; /* フォーカス時のブラウザ既定の枠線を非表示 */
 }
 .ytcm-tooltip {
   position: absolute;


### PR DESCRIPTION
マーカーをクリックした後に矢印キーを押すと、ブラウザ既定のフォーカス枠線
（outline）が表示されていた。CSSで outline: none を設定し、クリック後に
blur() でフォーカスを外すことで意図しない強調表示を防止。

https://claude.ai/code/session_013aFzbgPZwSAhNqNTmp7JXp